### PR TITLE
Fix broken example in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ uint32_t cnt;
 
 void setup(){
   cnt = 0;
-  while(sakuraio.getConnectionStatus() & 0x80) == 0x80){
+  while((sakuraio.getConnectionStatus() & 0x80) != 0x80){
     delay(1000);
   }
 }


### PR DESCRIPTION
- The example didn't build because of missing open parenthesis.
- The wait loop should exit only after connection status *does* have 0x80 on.