### PR TITLE
Using Repeated Start Condition

### DIFF
--- a/src/SakuraIO_I2C.cpp
+++ b/src/SakuraIO_I2C.cpp
@@ -41,7 +41,7 @@ void SakuraIO_I2C::sendByte(uint8_t data){
 
 uint8_t SakuraIO_I2C::startReceive(uint8_t length){
   dbgln("endTransmission");
-  Wire.endTransmission();
+  Wire.endTransmission(false);
   dbg("requestForm=");
   dbgln(length);
   Wire.requestFrom((uint8_t)SAKURAIO_SLAVE_ADDR, length, (uint8_t)true);


### PR DESCRIPTION
https://www.arduino.cc/en/Reference/WireEndTransmission

> If true, endTransmission() sends a stop message after transmission, releasing the I2C bus.
> 
> If false, endTransmission() sends a restart message after transmission. The bus will not be released, which prevents another master device from transmitting between messages. This allows one master device to send multiple transmissions while in control.
> 
> The default value is true.