### PR TITLE
Check sizeof(double)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ Please see example code.
 * [Shell](./examples/Shell/Shell.ino)
 * [Send illminance (CdS)](./examples/CdS/CdS.ino)
 
+# Notes
 
+* On the Uno and other ATMEGA based boards, Values ​​of type double are sent as float type. (Please see [Arduino Reference]( https://www.arduino.cc/reference/en/language/variables/data-types/double/).)
 
 # License
 

--- a/src/SakuraIO.cpp
+++ b/src/SakuraIO.cpp
@@ -164,6 +164,18 @@ uint8_t SakuraIO::enqueueTx(uint8_t ch, float value, uint64_t offset){
 }
 
 uint8_t SakuraIO::enqueueTx(uint8_t ch, double value, uint64_t offset){
+
+  // check sizeof(double)
+  //
+  // On the Uno and other ATMEGA based boards,
+  // this occupies 4 bytes. That is, the double
+  // implementation is exactly the same as the float,
+  // with no gain in precision.
+  // https://www.arduino.cc/reference/en/language/variables/data-types/double/
+  if (sizeof(double) == 4){
+    return enqueueTx(ch, (float)value, offset);
+  }
+
   return enqueueTxRaw(ch, 'd', 8, (uint8_t *)&value, offset);
 }
 


### PR DESCRIPTION
On the Uno and other ATMEGA based boards, the double type occupies 4 bytes.
[Arduino Reference](https://www.arduino.cc/reference/en/language/variables/data-types/double/)

Since double values ​​are transmitted as 64-bit values, check the `sizeof(double)`, and when it is 32 bits it is sent as a float type.


