### PR TITLE
Add SakuraIOUtils::double2float() helper function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - arduino --verify --board arduino:avr:uno $PWD/examples/Shell/Shell.ino
   - arduino --verify --board arduino:avr:uno $PWD/examples/Standard/Standard.ino
   - arduino --verify --board arduino:avr:uno $PWD/examples/CdS/CdS.ino
+  - arduino --verify --board arduino:avr:uno $PWD/examples/double2float/double2float.ino
 notifications:
   email:
     on_success: change

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Please see example code.
 
 * On the Uno and other ATMEGA based boards, Values ​​of type double are sent as float type. (Please see [Arduino Reference]( https://www.arduino.cc/reference/en/language/variables/data-types/double/).)
 
+* Please use SakuraIOUtils::double2float() when you want to handle the value of double type received as float. DO NOT USE C type casting. (Please see [the example](./examples/double2float/double2float.ino))
+
 # License
 
 The MIT License (MIT)

--- a/examples/double2float/double2float.ino
+++ b/examples/double2float/double2float.ino
@@ -1,0 +1,33 @@
+#include <SakuraIO.h>
+#include <SakuraIOUtils.h>
+
+//SakuraIO_SPI sakuraio(10);
+SakuraIO_I2C sakuraio;
+
+void setup(){
+
+}
+
+void loop(){
+  uint8_t ret;
+
+  uint8_t channel;
+  uint8_t type;
+  uint8_t values[8];
+  int64_t offset;
+  ret = sakuraio.dequeueRx(&channel, &type, values, &offset);
+
+  if (ret != 0x01) {
+    return;
+  }
+
+  if (type == 'd') {
+    float f = SakuraIOUtils::double2float(*((uint64_t *)values));
+
+    // On the Uno and other ATMEGA based boards, this occupies 4 bytes.
+    // That is, the double implementation is exactly the same as the float.
+    // DO NOT USE C type casting.
+    // double d = *((double *)values); // bad
+    // float f = (float)*((double *)values); // bad
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Provides functions for "sakura.io" (IoT platform of SAKURA Internet In
 category=Communication
 url=https://github.com/sakuraio/SakuraIOArduino
 architectures=*
-includes=SakuraIO.h
+includes=SakuraIO.h,SakuraIOUtils.h

--- a/src/SakuraIOUtils.cpp
+++ b/src/SakuraIOUtils.cpp
@@ -1,0 +1,21 @@
+#include "SakuraIOUtils.h"
+
+namespace SakuraIOUtils {
+
+  float double2float(uint64_t d){
+
+    uint8_t sign = d>>63;
+    uint32_t exponent = (d>>52) & 0x7ff;
+    uint64_t fraction = d & 0xfffffffffffff;
+
+
+    uint32_t fv = 0;
+    fv |= (uint32_t)sign << 31;
+    fv |= (uint32_t)(exponent>>3)<<23;
+    fv |= (uint32_t)(fraction>>29);
+
+    float *pf = (float *)&fv;
+    return *pf;
+  }
+
+}

--- a/src/SakuraIOUtils.h
+++ b/src/SakuraIOUtils.h
@@ -1,0 +1,10 @@
+#ifndef _SAKURAIOUTILS_H_
+#define _SAKURAIOUTILS_H_
+
+#include <stdint.h>
+
+namespace SakuraIOUtils {
+  float double2float(uint64_t d);
+}
+
+#endif // _SAKURAIOUTILS_H_


### PR DESCRIPTION
For Uno and other ATMEGA based boards. ( 4 bytes `double` type implementation )