### PR TITLE
Cast requestForm argument to uint8_t.

### DIFF
--- a/src/SakuraIO_I2C.cpp
+++ b/src/SakuraIO_I2C.cpp
@@ -19,7 +19,7 @@ void SakuraIO_I2C::end(){
       Wire.endTransmission();
       break;
     case MODE_READ:
-      Wire.requestFrom(SAKURAIO_SLAVE_ADDR, 1, true);
+      Wire.requestFrom((uint8_t)SAKURAIO_SLAVE_ADDR, (uint8_t)1, (uint8_t)true);
       if( Wire.available() ) Wire.read();
       break;
   }


### PR DESCRIPTION
Warning when build with SPRESENSE.

```
In file included from /Users/y-egusa/Documents/Arduino/libraries/SakuraIO/src/SakuraIO_I2C.cpp:1:0:
/Users/y-egusa/Library/Arduino15/packages/SPRESENSE/hardware/spresense/1.2.1/libraries/Wire/Wire.h: In member function 'virtual void SakuraIO_I2C::end()':
/Users/y-egusa/Library/Arduino15/packages/SPRESENSE/hardware/spresense/1.2.1/libraries/Wire/Wire.h:81:13: note: candidate 1: uint8_t TwoWire::requestFrom(int, int, int)
     uint8_t requestFrom(int address, int quantity, int sendStop) { return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)sendStop); }
             ^
/Users/y-egusa/Library/Arduino15/packages/SPRESENSE/hardware/spresense/1.2.1/libraries/Wire/Wire.h:79:13: note: candidate 2: uint8_t TwoWire::requestFrom(uint8_t, uint8_t, uint8_t)
     uint8_t requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop);
             ^
```