### PR TITLE
add a return statement

### DIFF
--- a/src/SakuraIO/debug.h
+++ b/src/SakuraIO/debug.h
@@ -3,6 +3,7 @@
 
 
 #if defined(SAKURA_DEBUG)
+#include <Arduino.h>
 #define dbg(...) Serial.print(__VA_ARGS__)
 #define dbgln(...) Serial.println(__VA_ARGS__)
 #else

--- a/src/SakuraIO_I2C.cpp
+++ b/src/SakuraIO_I2C.cpp
@@ -51,6 +51,7 @@ uint8_t SakuraIO_I2C::startReceive(uint8_t length){
   dbgln(length);
   Wire.requestFrom((uint8_t)SAKURAIO_SLAVE_ADDR, length, (uint8_t)true);
   mode = MODE_READ;
+  return length;
 }
 
 uint8_t SakuraIO_I2C::receiveByte(){


### PR DESCRIPTION
I added a return statement to SakuraIO_I2C::startReceive(). 
Because it crashes when it is returning from SakuraIO_I2C::startReceive() on M5StampS3.